### PR TITLE
added "parseBEDEV1ErrorFromStringAndHeaders" and "parseBEDEV2ErrorFromStringAndHeaders"

### DIFF
--- a/src/versions/BEDEV1.ts
+++ b/src/versions/BEDEV1.ts
@@ -50,3 +50,11 @@ export function parseBEDEV1Error(response: Response) {
         response.headers,
     );
 }
+
+export function parseBEDEV1ErrorFromStringAndHeaders(text: string, headers: Headers) {
+  return parseAnyError(
+    () => text.trim(),
+    parseBEDEV1ErrorFromJSON,
+    headers,
+  );
+}

--- a/src/versions/BEDEV2.ts
+++ b/src/versions/BEDEV2.ts
@@ -186,3 +186,11 @@ export function parseBEDEV2Error(response: Response) {
         response.headers,
     );
 }
+
+export function parseBEDEV2ErrorFromStringAndHeaders(text: string, headers: Headers) {
+  return parseAnyError(
+    () => text.trim(),
+    parseBEDEV2ErrorFromJSON,
+    headers,
+  );
+}


### PR DESCRIPTION
I have added 2 new functions ("parseBEDEV1ErrorFromStringAndHeaders" and "parseBEDEV2ErrorFromStringAndHeaders"). What they do is quite self-explanatory, they parse a BEDEV error from a string and headers.